### PR TITLE
[logging] Add support for new JsonPayload type

### DIFF
--- a/stackdriver/logging/write_data.go
+++ b/stackdriver/logging/write_data.go
@@ -1,10 +1,12 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
+	"google.golang.org/api/googleapi"
 	SDK "google.golang.org/api/logging/v2"
 )
 
@@ -51,8 +53,14 @@ func (d *WriteData) LogEntryList(projectID string) ([]*SDK.LogEntry, error) {
 	switch v := d.Data.(type) {
 	case string:
 		ent.TextPayload = v
+	case googleapi.RawMessage:
+		ent.JsonPayload = v
 	default:
-		ent.JsonPayload = d.Data
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		ent.JsonPayload = b
 	}
 
 	if d.Resource != nil {


### PR DESCRIPTION
This PR is supporting new LogEntry.JsonPayload type to fix compile error on Stackdriver logging.

See issue: https://github.com/evalphobia/google-api-go-wrapper/issues/6
