### PR TITLE
Config to try golang.org/x/oauth2/google.FindDefaultCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ client = analytics.New(config.Config{
 // use env parameter when above fields are empty.
 // $GOOGLE_API_GO_PRIVATEKEY : used as `PrivateKey` field.
 // $GOOGLE_API_GO_EMAIL : used as `Email` field.
-// $GOOGLE_APPLICATION_CREDENTIALS : used as `Filename` field.
 client = analytics.New(config.Config{})
 ```
+
+If no other credentials could be found, `Config` will use https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials.
 
 ## Google Analytics
 


### PR DESCRIPTION
The gcloud tool and other Google Go libraries search for credentials in
the environment. Config was implementing some of this behaviour itself
by checking `$GOOGLE_APPLICATION_CREDENTIALS`.

`golang.org/x/oauth2/google` package provides a helper for this, to not
only look in `$GOOGLE_APPLICATION_CREDENTIALS` but also default filenames
and metadata services.

This change removes the custom checking of `$GOOGLE_APPLICATION_CREDENTIALS`
and, if no other credentials were provided, uses FindDefaultCredentials
to find the relevant credentials. This keeps existing behaviour, but also
allows others to use other standard paths and methods to obtain
credentials like they may be doing elsewhere.